### PR TITLE
Fix loading subfolders from trainFolder by removing windows slash for…

### DIFF
--- a/Estrous Code/EstrousNetTrainer.m
+++ b/Estrous Code/EstrousNetTrainer.m
@@ -67,7 +67,7 @@ classdef EstrousNetTrainer < handle
         
         function [trainingDS, validationDS] = getData(obj, trainFolder, validationFolder)
             % Get raw data from files
-            subfolders = dir(strcat(trainFolder,'\*'));
+            subfolders = dir(fullfile(trainFolder,'*'));
             classes = {subfolders(3:end).name}; % labels from subfolder names
             trainingDS = imageDatastore(fullfile(trainFolder, classes), 'LabelSource', 'foldernames');
             validationDS = imageDatastore(fullfile(validationFolder, classes), 'LabelSource', 'foldername');


### PR DESCRIPTION
… linux compatibility

```
Warning: File contains uninterpretable data. 
> In importdata (line 78)
In EstrousNetGUI/loadNet (line 69)
In EstrousNetGUI/startupFcn (line 91)
In appdesigner.internal.service/AppManagementService/runStartupFcn (line 132)
In matlab.apps/AppBase/runStartupFcn (line 66)
In EstrousNetGUI (line 431) 
Choose your folder containing training data: 
Choose your folder containing validation data: 
71              classes = {subfolders(3:end).name}; % labels from subfolder names
Using 'resnet50'
Incorrect number or types of inputs or outputs for function categories.

Error in EstrousNetTrainer/setNetwork (line 98)
            numClasses = numel(categories(obj.trainingDS.Labels));
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error in EstrousNetTrainNewNet/TRAINESTROUSNETButtonPushed (line 129)
                app.trainer.setNetwork(app.SelectanetDropDown.Value);
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error in matlab.apps.AppBase>@(source,event)executeCallback(ams,app,callback,requiresEventData,event) (line 60)
            newCallback = @(source, event)executeCallback(ams, ...
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
Error while evaluating Button PrivateButtonPushedFcn.
```